### PR TITLE
expose job id as env var $STRIDER_JOB_ID

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,7 @@
 
 module.exports = {
   init: function (config, job, context, done) {
+    config.STRIDER_JOB_ID = job._id;
     done(null, {
       env: config
     })


### PR DESCRIPTION
not sure if we should merge this... leaving it here to start the discussion of if strider-env's scope should be to expose Strider-specific vars too... it may be a good idea? maybe add check marks or something so that it's opt-in ? e.g. 
- [ ] Set STRIDER_JOB_ID ?

https://github.com/Strider-CD/strider/issues/496
