### PR TITLE
Include a VCS_BRANCH environment variable

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,9 +1,13 @@
 
 module.exports = {
   init: function (config, job, context, done) {
+    // add a VCS_BRANCH environment variable if it is not set
+    if ( typeof config.VCS_BRANCH === 'undefined' ) {
+      config.VCS_BRANCH = job.ref && job.ref.branch ? job.ref.branch : 'master';
+    }
     done(null, {
       env: config
-    })
+    });
   }
 }
 


### PR DESCRIPTION
When using the environment plugin, the current branch name will be exported to the `VCS_BRANCH` environment variable unless this one exists.

This will make it easier to find out what branch is currently being tested when the build is triggered from GitHub hook where it is then in detached head, see Strider-CD/strider#474
