### PR TITLE
[api] .env file client-side "upload" and parsing [#6]

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -28,6 +28,11 @@
           <td><input ng-model="newvalue" placeholder="New Value" type="text"></td>
           <td><button ng-click="add()" class="btn btn-success">Add</button></td>
         </tr>
+        <tr>
+          <td>Select a .env file: <input type="file" fileread="parsedenv.src"></td>
+          <td><span ng-bind="filereadstatus"></span></td>
+          <td><button ng-click="upload()" class="btn btn-primary">Upload</button></td>
+        </tr>
       </tbody>
     </table>
   </fieldset>

--- a/config/config.js
+++ b/config/config.js
@@ -1,9 +1,58 @@
+app.directive("fileread", [function () {
+  return {
+    scope: {
+      fileread: "="
+    },
+    link: function (scope, element, attributes) {
+      element.bind("change", function (changeEvent) {
+        var file = changeEvent.target.files[0],
+            reader = new FileReader();
+
+        reader.onload = function (loadEvent) {
+          var fileContents = loadEvent.target.result,
+              env;
+
+          try {
+            env = JSON.parse(fileContents);
+          } catch (e) {}
+
+          if (!env) try {
+            var obj = {},
+                lines = fileContents.split("\n");
+
+            for (var i = 0; i < lines.length - 1; i++) {
+              var pair = lines[i].split("=");
+              obj[pair[0].trim()] = pair[1].trim();
+            }
+            env = obj;
+          } catch (e) {}
+
+          if (!env) {
+            scope.$apply(function () {
+              scope.filereadstatus = "Error: unable to parse .env file.";
+            });
+            return;
+          }
+
+          scope.$apply(function () {
+            scope.fileread = env;
+            scope.filereadstatus = "Ready to add.";
+          });
+        }
+        reader.readAsText(file);
+      });
+    }
+  }
+}]);
 
 app.controller('EnvironmentCtrl', ['$scope', function ($scope) {
   $scope.$watch('configs[branch.name].env.config', function (value) {
     $scope.config = value || {};
   });
   $scope.saving = false;
+  $scope.parsedenv = {};
+  $scope.parsedenv.src = "";
+  $scope.filereadstatus = "";
   $scope.save = function () {
     $scope.saving = true;
     $scope.pluginConfig('env', $scope.config, function () {
@@ -17,6 +66,13 @@ app.controller('EnvironmentCtrl', ['$scope', function ($scope) {
   $scope.add = function () {
     $scope.config[$scope.newkey] = $scope.newvalue;
     $scope.newkey = $scope.newvalue = '';
+    $scope.save();
+  };
+  $scope.upload = function () {
+    var env = $scope.parsedenv.src;
+    for (var key in env) {
+      $scope.config[key] = env[key];
+    }
     $scope.save();
   };
 }]);


### PR DESCRIPTION
Ability to import environment variables in .env file format, as JSON or key/value "="-split pairs.  Format compatible with Heroku, Foreman, [node-foreman](//github.com/strongloop/node-foreman).

This is the first time I've written Angular, so feel free to point out improvements. Angular's lack of ng-model and ng-change support for file inputs makes it a hairy solution.